### PR TITLE
Restrict to matplotlib<2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - no_compile_setup.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -42,7 +42,7 @@ requirements:
     - cf_units
     - pyke
     - mo_pack  # [not win]
-    - matplotlib
+    - matplotlib <2
     - nc_time_axis
     - iris-grib  # [not (win or py3k)]
 


### PR DESCRIPTION
The [cartopy-feedstock](https://github.com/conda-forge/cartopy-feedstock/blob/master/recipe/meta.yaml#L37) recipe is limited to use `matplotlib <2`.

`cartopy` is not yet ready or tested against `matplotlib` `2.0.0` and `iris` is only tested up to `matplotlib` `1.5.3`.

At the moment `iris` allows matplotlib `2.0.0` to be pulled in. We should throttle this back (for now) on this until `iris` and `cartopy` are tested and good to go with the latest `matplotlib`.