### PR TITLE
Unpin netcdf4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - no_compile_setup.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -36,8 +36,7 @@ requirements:
     - cartopy >=0.14
     - cf_units
     - pyke
-    # See https://github.com/SciTools/iris/issues/2322
-    - netcdf4 <=1.2.4
+    - netcdf4
     - mo_pack  # [not win]
     - matplotlib
     - nc_time_axis


### PR DESCRIPTION
https://github.com/SciTools/iris/issues/2322  was not closed but it seems that the tests are passing upstream (and this pin is hurting the users more than the date issue reported there.)