### PR TITLE
Update to dask 0.17.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8605ab92c67d622e83fff6d7169fe154d9f8610edd8463b697b574884c158ba2
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -17,7 +17,7 @@ requirements:
     - pip
     - cartopy >=0.14
     - cf_units
-    - dask >=0.15.3
+    - dask >=0.17.1
     - numpy
     - pyke
     - scipy
@@ -26,7 +26,7 @@ requirements:
     - python
     - cartopy >=0.14
     - cf_units
-    - dask >=0.15.3
+    - dask >=0.17.1
     - matplotlib
     - netcdf4
     - numpy


### PR DESCRIPTION
Until Dask 0.17.1 there was a bug where computing scalar arrays could result in errors (https://github.com/dask/dask/issues/2823). We had a workaround in Iris which we took out after a fixed version of Dask was released. We should have also updated the minimum version of Dask here and in the Iris requirements.