### PR TITLE
Pin netcdf4 dependency to <1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8605ab92c67d622e83fff6d7169fe154d9f8610edd8463b697b574884c158ba2
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -28,7 +28,7 @@ requirements:
     - cf_units
     - dask >=0.17.1
     - matplotlib
-    - netcdf4
+    - netcdf4 <1.4
     - numpy
     - pyke
     - scipy


### PR DESCRIPTION
We need a new build of Iris 2.0.0 that uses a version of netcdf4 before netcdftime was taken out.

