### PR TITLE
Remove netcdf pin, and iris-grib dependency.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8605ab92c67d622e83fff6d7169fe154d9f8610edd8463b697b574884c158ba2
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -28,12 +28,10 @@ requirements:
     - cf_units
     - dask >=0.17.1
     - matplotlib
-    - netcdf4 <1.4
     - numpy
     - pyke
     - scipy
     - six
-    - iris-grib  # [not (win or py3k)]
 
 test:
   imports:


### PR DESCRIPTION
Latest netcdf should now be ok, since we now have cf_units 2.0 (see [earlier comment saying that](https://github.com/conda-forge/iris-feedstock/pull/28#issuecomment-388840180) ).

Iris-grib should **not** be counted as a dependency; it is a strictly optional extra.

