### PR TITLE
unpin build pin for numpy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9e4cc7ebb41efcd67ece39c39d09fcacadc7ae9d2024fe954bb8149e1b9f7570
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
     - cf_units >=2
     - cftime
     - dask >=0.17.1
-    - numpy >=1.14
+    - numpy
     - pyke
     - scipy
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,3 +56,4 @@ extra:
     - bjlittle
     - dkillick
     - corinnebosley
+    - lbdreyer


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The pin of `numpy >=1.14` for the `build` requirements is unnecessarily restrictive. There is no need to raise the bar so high at build time - plus this will cause issues within conda environments with regards to how `iris` relates to other packages in that environment.
