### PR TITLE
removed the not numpy 1.15.2 pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 3ba0b78b93cb69d8c865b9cdcde57be2da9b174096a1c075e6fc9188c8f8afd1
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
     - cf_units >=2
     - cftime
     - dask
-    - numpy >=1.14, !=1.15.2
+    - numpy >=1.14
     - pyke
     - scipy
     - six


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Removed 'not numpy 1.15.2' pin as issues with numpy 1.15.2 build have now been fixed (see https://github.com/conda-forge/iris-feedstock/pull/41#discussion_r224928363).
