### PR TITLE
use cf-units instead of cf_units

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,14 +9,14 @@ source:
   sha256: 3ba0b78b93cb69d8c865b9cdcde57be2da9b174096a1c075e6fc9188c8f8afd1
 
 build:
-  number: 1002
+  number: 1003
 
 requirements:
   build:
     - python
     - pip
     - cartopy >=0.14
-    - cf_units >=2
+    - cf-units >=2
     - cftime !=1.0.2.1
     - dask
     - numpy >=1.14
@@ -26,7 +26,7 @@ requirements:
   run:
     - python
     - cartopy >=0.14
-    - cf_units >=2
+    - cf-units >=2
     - cftime !=1.0.2.1
     - dask
     - matplotlib >=2


### PR DESCRIPTION
We are pulling an older version b/c of the rename, this should get the latest one.