### PR TITLE
Recipe updates for v3.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/iris-feedstock/
 
 Home: https://scitools-iris.readthedocs.io/en/stable/
 
-Package license: LGPL-3.0-or-later
+Package license: BSD-3-Clause
 
 Summary: Analyse and visualise meteorological and oceanographic data sets.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.7.1" %}
+{% set version = "3.8.1" %}
 
 package:
   name: iris
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/scitools-iris/scitools-iris-{{ version }}.tar.gz
-  sha256: 5523115b6bca7f632661a2f4b7564ba5fc5565117201a77cb0755cb45763ba4b
+  sha256: bf1f35053c16c14938ee0a1a6cfa7ab60804cf1ec79bac5b550179354370d4fc
 
 build:
   noarch: python
@@ -33,7 +33,7 @@ outputs:
         - libnetcdf !=4.9.1
         - matplotlib-base >=3.5
         - netcdf4
-        - numpy >=1.21,!=1.24.3
+        - numpy >=1.23,!=1.24.3
         - pyproj
         - scipy
         - shapely !=1.8.3
@@ -54,9 +54,9 @@ outputs:
         - iris
 about:
   home: https://scitools-iris.readthedocs.io/en/stable/
-  license: LGPL-3.0-or-later
-  license_family: GPL
-  license_file: COPYING.LESSER
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
   summary: Analyse and visualise meteorological and oceanographic data sets.
 
 extra:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* ~~Bumped the build number (if the version is unchanged)~~
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This diff should demonstrate that the recipe has the MINIMUM differences with `v3.8.0` (i.e. it restores the new BSD licence and has the latest dependency pins):

https://github.com/conda-forge/iris-feedstock/compare/8eb6ea037db1012f7e6d7d978a3b7ca02edae941...e1df54f736dbea0fdc69942535f7e76de8b584e4